### PR TITLE
use absolute paths for python so it can be called from wherever

### DIFF
--- a/astra.api/leaves.api.python/app.py
+++ b/astra.api/leaves.api.python/app.py
@@ -7,6 +7,7 @@ from flask import Flask, jsonify, request, abort, Response
 import hashlib
 from bs4 import BeautifulSoup
 import re
+import os
 import readtime
 from flask_cors import CORS
 
@@ -69,10 +70,13 @@ def processURL(url):
 
 
 #Connect to Astra Cluster
-with open('astra.credentials/UserCred.json') as f:
+path_to_this_file = os.path.abspath(os.path.dirname(__file__))
+creds_dir = os.path.join(path_to_this_file, '../../', 'astra.credentials')
+with open(os.path.join(creds_dir, 'UserCred.json')) as f:
     cred = json.load(f)
+
 cloud_config= {
-        'secure_connect_bundle': 'astra.credentials/secure-connect-'+cred['cluster']+'.zip'
+        'secure_connect_bundle': os.path.join(creds_dir, 'secure-connect-'+cred['cluster']+'.zip')
 }
 auth_provider = PlainTextAuthProvider(cred['username'], cred['password'])
 cluster = Cluster(cloud=cloud_config, auth_provider=auth_provider)


### PR DESCRIPTION
This makes it possible for users to run the flask server from any directory they want to. Avoids issues such as:

![image](https://user-images.githubusercontent.com/22231483/91932044-f7d05b00-ec99-11ea-8d63-586df3f2334f.png)

Expected behavior works after this commit:
![image](https://user-images.githubusercontent.com/22231483/91932077-0b7bc180-ec9a-11ea-8348-31dbcf20040f.png)
